### PR TITLE
Move dismissing from signature view controller to the presenting view controller

### DIFF
--- a/MPBSignatureViewController/MPBCustomStyleSignatureViewController.m
+++ b/MPBSignatureViewController/MPBCustomStyleSignatureViewController.m
@@ -163,14 +163,10 @@ NSString *const MPBSignatureViewBundleName = @"MPBSignatureViewResources";
 
 - (void)continueWithSignature {
     self.continueBlock([self signature]);
-    [self dismissViewControllerAnimated:YES completion:^{
-    }];
 }
 
 - (void) cancelSignature {
     self.cancelBlock();
-    [self dismissViewControllerAnimated:YES completion:^{
-    }];
 }
 
 - (void) enableContinueAndClearButtons {

--- a/TestApp/MPBViewController.m
+++ b/TestApp/MPBViewController.m
@@ -73,8 +73,12 @@
     vc.configuration = config;
     vc.continueBlock = ^(UIImage *signature) {
         [self showImage: signature];
+        
+        [self dismissViewControllerAnimated:YES completion:nil];
     };
-    vc.cancelBlock =^{};
+    vc.cancelBlock =^{
+        [self dismissViewControllerAnimated:YES completion:nil];
+    };
     
     [self presentViewController:vc animated:YES completion:nil];
 }
@@ -92,9 +96,10 @@
     
     signatureViewController.continueBlock = ^(UIImage *signature) {
         [self showImage: signature];
+        [self dismissViewControllerAnimated:YES completion:nil];
     };
     signatureViewController.cancelBlock = ^ {
-        
+        [self dismissViewControllerAnimated:YES completion:nil];
     };
     
 


### PR DESCRIPTION
In accordance to Apple docs:

The presenting view controller is responsible for dismissing the view controller it presented.

https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/#//apple_ref/occ/instm/UIViewController/dismissViewControllerAnimated:completion: